### PR TITLE
[Anon] File update: BA - Japan.cat

### DIFF
--- a/BA - Japan.cat
+++ b/BA - Japan.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2daaca48-bb03-1c9c-509c-854e40417697" revision="9" gameSystemId="dd1c28f5-7a1e-e616-4caa-87ff07e7d4f1" gameSystemRevision="1" battleScribeVersion="1.15" name="Armies of Imperial Japan" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2daaca48-bb03-1c9c-509c-854e40417697" revision="10" gameSystemId="dd1c28f5-7a1e-e616-4caa-87ff07e7d4f1" gameSystemRevision="1" battleScribeVersion="1.15" name="Armies of Imperial Japan" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries/>
   <rules>
     <rule id="a47d1ec8-07e9-2bf0-7275-169d82b3a4c9" name="Banzai Charge" hidden="false" page="0">
@@ -111,9 +111,6 @@
       <modifiers/>
     </link>
     <link id="8751-bde3-3e24-813e" targetId="9c77e692-d023-ef75-0f2c-2bd595ece5b2" linkType="entry" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
-      <modifiers/>
-    </link>
-    <link id="639b-2274-b72e-639e" targetId="8b5c897e-7563-5dbf-9a7b-6dbe62badb54" linkType="entry" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
       <modifiers/>
     </link>
     <link id="5882-4541-0a11-57c0" targetId="4ead6b4e-ce07-7c2d-bd31-a753ddabe9d4" linkType="entry" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
@@ -279,6 +276,9 @@
       <modifiers/>
     </link>
     <link id="61ed-c8cd-5f59-50d6" targetId="3321-3ebc-c892-c448" linkType="entry" categoryId="014468cf-931f-6d22-82c8-56acf4032768">
+      <modifiers/>
+    </link>
+    <link id="1183-45c0-866c-f149" targetId="3b3f-b708-0f33-2209" linkType="entry" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
       <modifiers/>
     </link>
   </links>
@@ -7722,6 +7722,74 @@
       </profiles>
       <links>
         <link id="760bb1ac-50e6-72a9-f332-c3c0bb1e2810" targetId="a194d545-a4c7-b609-5e9a-2e82339215e9" linkType="rule">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="3b3f-b708-0f33-2209" name="Type 1 47MM AT Gun" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups>
+        <entryGroup id="3711-fe41-3ffb-5b7b" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+          <entries>
+            <entry id="cc45-aa14-d5d3-79ca" name="Veteran" points="90.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="bc17-9dcb-8337-8c22" targetId="3ffe9a5e-48cc-2400-5d45-7526a1e19df7" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="353d-7373-02bb-7332" name="Regular" points="75.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="7a6a-d5ad-dcbf-3c8e" targetId="84ac532d-2657-cb2d-c314-9ef981f39bc9" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+            <entry id="46b7-5d44-e837-aaeb" name="Inexperienced" points="60.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+              <entries/>
+              <entryGroups/>
+              <modifiers/>
+              <rules/>
+              <profiles/>
+              <links>
+                <link id="accd-d02e-86c7-d550" targetId="109d237f-140f-68df-f0a5-d09ffa18e6b6" linkType="profile">
+                  <modifiers/>
+                </link>
+              </links>
+            </entry>
+          </entries>
+          <entryGroups/>
+          <modifiers/>
+          <links/>
+        </entryGroup>
+      </entryGroups>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="a0b6-4fef-9609-eff0" targetId="ec07765d-5037-08c2-6533-9d99511f208d" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="3ba6-1b55-0ce3-f81e" targetId="127e3232-13b3-10fc-dd2b-d89cbf04c739" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="e82d-74df-61dd-7dae" targetId="75a15bd5-b7f9-eb24-bf97-f6517ea3b4b4" linkType="rule">
+          <modifiers/>
+        </link>
+        <link id="cb6a-5abd-5f64-ff83" targetId="e69afc1d-4039-43f4-7af3-d6e7936f61a0" linkType="entry">
+          <modifiers/>
+        </link>
+        <link id="e801-80a1-823c-eb3e" targetId="f1b7e27d-d587-d97f-6c55-34713f1ff7ab" linkType="rule">
           <modifiers/>
         </link>
       </links>


### PR DESCRIPTION
**File:** BA - Japan.cat

**Description:** The type 1 47mm anti-tank fun is not a choice available in the artillery section when designing an army. It appears to have the 37mm light anti-tank fun twice for selection.

Removed one 37mm AT and added 47mm AT.