### PR TITLE
[Anon] File update: BA - Armies of the United States.cat

### DIFF
--- a/BA - Armies of the United States.cat
+++ b/BA - Armies of the United States.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="49f05393-294d-1013-a9bb-a7279fd20846" revision="14" gameSystemId="dd1c28f5-7a1e-e616-4caa-87ff07e7d4f1" gameSystemRevision="1" battleScribeVersion="1.15" name="Armies of the United States" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="49f05393-294d-1013-a9bb-a7279fd20846" revision="16" gameSystemId="dd1c28f5-7a1e-e616-4caa-87ff07e7d4f1" gameSystemRevision="1" battleScribeVersion="1.15" name="Armies of the United States" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entries/>
   <rules>
     <rule id="89d97e79-cfe5-c413-05db-90a62f2dcb14" name="Gyro-stabilisers" hidden="false" page="0">
@@ -638,7 +638,7 @@
         </link>
       </links>
     </entry>
-    <entry id="b34f7000-8fe0-10fe-d4e7-5c1dd5fd72b8" name="3-Inch AT-Gun M5" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="b34f7000-8fe0-10fe-d4e7-5c1dd5fd72b8" name="3-Inch AT-Gun M5" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="0e140548-e287-c622-2420-a1c25f46ee91" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -706,7 +706,7 @@
         </link>
       </links>
     </entry>
-    <entry id="63d39485-9190-2327-85bb-fb67aa3aaf50" name="37MM AT-Gun M3" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="63d39485-9190-2327-85bb-fb67aa3aaf50" name="37MM AT-Gun M3" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="560ec756-0691-3853-0c20-75f571410012" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -774,7 +774,7 @@
         </link>
       </links>
     </entry>
-    <entry id="10e4104e-ef94-a2fe-1167-c074fa2607f8" name="37MM M1A2 Medium AA Gun" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="10e4104e-ef94-a2fe-1167-c074fa2607f8" name="37MM M1A2 Medium AA Gun" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="77966aa6-00e8-3495-9689-bba48a40879a" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -866,7 +866,7 @@
         </link>
       </links>
     </entry>
-    <entry id="fcfe933f-d450-a032-bf62-3d17bf9c100f" name="57MM AT-Gun M1" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="fcfe933f-d450-a032-bf62-3d17bf9c100f" name="57MM AT-Gun M1" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="8e4bf1e7-ff8a-248f-471f-3417c5e75f76" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -934,7 +934,7 @@
         </link>
       </links>
     </entry>
-    <entry id="7c9efe0c-512f-5270-9bb1-a23bc09367be" name="57MM M18" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="7c9efe0c-512f-5270-9bb1-a23bc09367be" name="57MM M18" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="76d0683b-0f46-42e4-1254-6f919792d115" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -990,7 +990,7 @@
         </link>
       </links>
     </entry>
-    <entry id="6222bb91-6ab5-4e66-f3ed-37bf3a6c47b7" name="75MM M20" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="6222bb91-6ab5-4e66-f3ed-37bf3a6c47b7" name="75MM M20" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="80e73e79-f40d-3fe6-acb9-51515b254a9a" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -1046,7 +1046,7 @@
         </link>
       </links>
     </entry>
-    <entry id="827c5f40-2390-5887-686a-8d783eee1529" name="90MM M2 Dual Purpose AA/AT Gun" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="827c5f40-2390-5887-686a-8d783eee1529" name="90MM M2 Dual Purpose AA/AT Gun" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="d30b71dd-e533-acb6-1874-7cf4bac80468" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -1134,7 +1134,7 @@
         </link>
       </links>
     </entry>
-    <entry id="a47bafae-7c6c-b600-a0a3-70bd0bae5e36" name="Bazooka Team" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="a47bafae-7c6c-b600-a0a3-70bd0bae5e36" name="Bazooka Team" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="dc31c734-8bd9-7975-d69d-5bd1444676a6" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -1535,7 +1535,7 @@
       <entries>
         <entry id="e7426cc4-7916-e4d4-d5f4-7b1de3f5d72c" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="e76742b9-5773-635a-edb3-e3004f2a7fda" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="e76742b9-5773-635a-edb3-e3004f2a7fda" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -1682,7 +1682,7 @@
       <entries>
         <entry id="4624c4bf-c9cf-ffdd-987d-f10f66cd779a" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="2bc924c8-030d-81db-ab11-35fdea0d9149" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="2bc924c8-030d-81db-ab11-35fdea0d9149" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -1853,7 +1853,7 @@
         </link>
       </links>
     </entry>
-    <entry id="14d677d7-044b-a98d-00e6-77449ef15414" name="Flamethrower Team" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="14d677d7-044b-a98d-00e6-77449ef15414" name="Flamethrower Team" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="abc923e9-73ec-4a40-edbe-abc272e8a0fb" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -2062,7 +2062,7 @@
         </link>
       </links>
     </entry>
-    <entry id="5932b2c8-0857-e199-b1de-41ad22c961d5" name="Forward Observer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="5932b2c8-0857-e199-b1de-41ad22c961d5" name="Forward Observer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="ce086fe5-e595-c680-6d18-41be72cd42dc" name="Observer" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -2538,7 +2538,7 @@
         </link>
       </links>
     </entry>
-    <entry id="59314d41-2f88-47b7-77b1-967a22e08de9" name="Heavy Artillery" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="59314d41-2f88-47b7-77b1-967a22e08de9" name="Heavy Artillery" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="80c31923-3e2f-a3c2-0bb1-4220b1d1b459" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -2645,7 +2645,7 @@
         </link>
       </links>
     </entry>
-    <entry id="0ce8d95b-dc02-523b-1a3b-df23b14bea70" name="Heavy Machine Gun Team" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="3" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="0ce8d95b-dc02-523b-1a3b-df23b14bea70" name="Heavy Machine Gun Team" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="3" minInForce="0" maxInForce="3" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="5f033bb0-c021-7c71-e254-75430d00cc49" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -3384,7 +3384,7 @@
       <entries>
         <entry id="4190932b-9a19-9520-b176-bca06e018177" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="821182de-fac1-affe-2309-831aad33ce2f" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="821182de-fac1-affe-2309-831aad33ce2f" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -3597,7 +3597,7 @@
       </profiles>
       <links/>
     </entry>
-    <entry id="adfc0164-934e-1d8e-dd26-a2e00f7261b3" name="Light Artillery" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="adfc0164-934e-1d8e-dd26-a2e00f7261b3" name="Light Artillery" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="f4ee4ef0-9131-2f8e-b66e-923b06bc58d6" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -4309,6 +4309,30 @@
           <modifiers/>
         </link>
         <link id="331a139a-2127-a7a1-3607-6f14d0ee8cb1" targetId="cf7f6cc8-a8cb-9a82-b3b2-a23ab8dc2a18" linkType="entry">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="c023d12f-abd8-d7ba-03b5-ea21d0240ed0" name="M1 Garand rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="2be53a3a-a992-8b9b-0ba2-7065b9bc17dd" targetId="d10b9427-70b3-2959-561d-6546fd4788cc" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
+    <entry id="898f-2600-c56e-dbd5" name="M1 Garand rifle or carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="e586-db14-04ae-2d51" targetId="d10b9427-70b3-2959-561d-6546fd4788cc" linkType="profile">
           <modifiers/>
         </link>
       </links>
@@ -5133,7 +5157,7 @@
         </link>
       </links>
     </entry>
-    <entry id="acf6d365-bf2c-9a06-f3a1-4811785069ea" name="M24 Chaffee" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="acf6d365-bf2c-9a06-f3a1-4811785069ea" name="M24 Chaffee" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="7a11ecbd-b0ce-1004-ed02-b8f2ff721dc5" name="Recce" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -5233,7 +5257,7 @@
         </link>
       </links>
     </entry>
-    <entry id="68354554-78e9-0024-f2f2-e8916b02235e" name="M26 Pershing" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="68354554-78e9-0024-f2f2-e8916b02235e" name="M26 Pershing" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="a760a32f-694e-697b-2453-b84ebbf3f699" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -6043,7 +6067,7 @@
         </link>
       </links>
     </entry>
-    <entry id="941fe8a1-321d-2866-7552-831c8c6917a6" name="M3 Stuart Light Tank" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="941fe8a1-321d-2866-7552-831c8c6917a6" name="M3 Stuart Light Tank" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="7e779e49-10ae-a6f9-3618-c83ac36766cd" name="Recce" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -6595,7 +6619,7 @@
         </link>
       </links>
     </entry>
-    <entry id="1564d874-511b-792a-a2f6-bfc66fe3c13b" name="M3A1 With Satan Flamethrower" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="1564d874-511b-792a-a2f6-bfc66fe3c13b" name="M3A1 With Satan Flamethrower" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="b72621db-024d-f286-13bd-6d8a30d555d7" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -6755,7 +6779,7 @@
         </link>
       </links>
     </entry>
-    <entry id="fabd2b21-4236-a77f-aad5-0f81642a1893" name="M3A3 Stuart" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="fabd2b21-4236-a77f-aad5-0f81642a1893" name="M3A3 Stuart" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="2091b1dd-8af0-3890-afa9-36cda2f38f83" name="Recce" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7041,7 +7065,7 @@
         </link>
       </links>
     </entry>
-    <entry id="9950d2c7-02a2-c47e-c233-ff7f8245f276" name="M4 Sherman 105MM Howitzer" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="9950d2c7-02a2-c47e-c233-ff7f8245f276" name="M4 Sherman 105MM Howitzer" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="ec5f4725-488c-19f5-379b-a1f48eedc193" name="A1" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7156,7 +7180,7 @@
         </link>
       </links>
     </entry>
-    <entry id="1134c47f-160e-7bd8-a620-cdb950dd0b62" name="M4 Sherman 75MM" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="1134c47f-160e-7bd8-a620-cdb950dd0b62" name="M4 Sherman 75MM" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="38ce0718-3689-e36f-6931-4cf705162d7c" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -7258,7 +7282,7 @@
         </link>
       </links>
     </entry>
-    <entry id="e46c1092-f122-4e3d-ae77-fe5d09508312" name="M4 Sherman T34 Calliope" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="e46c1092-f122-4e3d-ae77-fe5d09508312" name="M4 Sherman T34 Calliope" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="1de48faa-8367-a15d-58f9-7dc8dc60e5dc" name="Turret-mounted multiple launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7516,7 +7540,7 @@
         </link>
       </links>
     </entry>
-    <entry id="2c3ac5a6-0068-4625-93e3-cd5533092aee" name="M4A1/A2/A3 Sherman 76MM" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="2c3ac5a6-0068-4625-93e3-cd5533092aee" name="M4A1/A2/A3 Sherman 76MM" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="27c8542d-e1a9-83e7-792d-702369bb75e2" name="Culin Hedgerow cutter" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7616,7 +7640,7 @@
         </link>
       </links>
     </entry>
-    <entry id="c9d69fb7-04e7-16ef-d574-43f3c887933c" name="M4A1/A2/A3/A4 Sherman 75MM" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="c9d69fb7-04e7-16ef-d574-43f3c887933c" name="M4A1/A2/A3/A4 Sherman 75MM" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="44d91b9d-5292-6538-d65c-96340f564ca6" name="M4A3" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7716,7 +7740,7 @@
         </link>
       </links>
     </entry>
-    <entry id="9148e700-c8f9-bec7-1939-4cb1550566d7" name="M4A2 Sherman &apos;Zippo&apos; or &apos;Ronson&apos; Crocodile Flamethrower" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="9148e700-c8f9-bec7-1939-4cb1550566d7" name="M4A2 Sherman &apos;Zippo&apos; or &apos;Ronson&apos; Crocodile Flamethrower" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="7bc52f71-ad0c-5584-7e13-f86739a14081" name="Sherman Crocodile" points="-10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="-10.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -7814,7 +7838,7 @@
         </link>
       </links>
     </entry>
-    <entry id="ff29c1ea-4d78-13af-7d2a-d7252f6ee7b9" name="M4A3/A4 Sherman 105MM Howitzer" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="ff29c1ea-4d78-13af-7d2a-d7252f6ee7b9" name="M4A3/A4 Sherman 105MM Howitzer" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="ab528adf-9e0f-3bd1-87ab-2db19fe4fc31" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -7918,7 +7942,7 @@
         </link>
       </links>
     </entry>
-    <entry id="bb40ee39-3f69-6912-dd80-644af63c1e2e" name="M4A3E2 Sherman &apos;Jumbo&apos; Heavy Assault Tank" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="bb40ee39-3f69-6912-dd80-644af63c1e2e" name="M4A3E2 Sherman &apos;Jumbo&apos; Heavy Assault Tank" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="a06254dc-9ee0-63ec-8c4c-161138f3addf" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -8036,7 +8060,7 @@
         </link>
       </links>
     </entry>
-    <entry id="c88d2a3c-3f9d-b193-5c2b-68e9acf6773c" name="M5/M5A1 Stuart" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="c88d2a3c-3f9d-b193-5c2b-68e9acf6773c" name="M5/M5A1 Stuart" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries>
         <entry id="06a648bb-f608-87ac-bd2d-bded920bcda1" name="Culin Hedgerow cutter" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries/>
@@ -8361,7 +8385,7 @@
         </link>
       </links>
     </entry>
-    <entry id="bf533570-0e82-d02a-b9c2-09db2c9ff98d" name="M8 Scott" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="bf533570-0e82-d02a-b9c2-09db2c9ff98d" name="M8 Scott" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="311aa135-ce8e-8d46-b637-18be07a04528" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -8758,7 +8782,7 @@
       <profiles/>
       <links/>
     </entry>
-    <entry id="b4391725-3538-be98-4e93-17274af29fb2" name="Medium Artillery" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="b4391725-3538-be98-4e93-17274af29fb2" name="Medium Artillery" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="6bd40d66-e23d-82ef-8ef4-5d39886abd98" name="Rating" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -9214,7 +9238,7 @@
       <entries>
         <entry id="d57356ff-34f2-2977-2f9c-d34c35dccf7a" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="85bab7fe-c9a5-e3ce-f78c-b856230efb71" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="85bab7fe-c9a5-e3ce-f78c-b856230efb71" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -9366,6 +9390,18 @@
         </link>
       </links>
     </entry>
+    <entry id="ad1d-b23e-6f69-c8d8" name="Pintle-Mounted HMG (360)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+      <entries/>
+      <entryGroups/>
+      <modifiers/>
+      <rules/>
+      <profiles/>
+      <links>
+        <link id="83b3-cea4-e687-4f36" targetId="a28fc6be-65f0-d015-c528-15adca14d14a" linkType="profile">
+          <modifiers/>
+        </link>
+      </links>
+    </entry>
     <entry id="2c5c31ba-32d4-dce6-a361-cca6d6bf1bab" name="Pintle-Mounted MMG (360)" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups/>
@@ -9498,7 +9534,7 @@
         </link>
       </links>
     </entry>
-    <entry id="c179b253-804c-db7d-50c4-0bfaac8aa7d9" name="Platoon Commander" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+    <entry id="c179b253-804c-db7d-50c4-0bfaac8aa7d9" name="Platoon Commander" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
       <entryGroups>
         <entryGroup id="c976b356-c0b4-9e64-37e3-e50eb15ce5f4" name="Rank" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
@@ -10104,7 +10140,7 @@
         </entryGroup>
       </entryGroups>
       <modifiers>
-        <modifier type="set" field="minInRoster" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="minInForce" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
           <conditions>
             <condition parentId="force type" childId="ee766e00-0168-11be-e251-23243581de9e" field="selections" type="instance of" value="0.0"/>
           </conditions>
@@ -10215,7 +10251,7 @@
       <entries>
         <entry id="c6866c10-726d-580b-9c69-f104fabfbea4" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="5c29fc6f-1771-159a-a783-07d380e3fc0a" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="5c29fc6f-1771-159a-a783-07d380e3fc0a" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="11" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -10366,7 +10402,7 @@
       <entries>
         <entry id="7aa7769b-2484-1584-5802-be4662db43a1" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="f2ffd0f7-7e89-1587-764d-af7723fe3ee7" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="f2ffd0f7-7e89-1587-764d-af7723fe3ee7" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -10498,7 +10534,7 @@
       <entries>
         <entry id="c3341c50-0c4f-7343-97f0-a19a4f0b400c" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="223856ae-5a22-0f4e-80da-041588728866" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="223856ae-5a22-0f4e-80da-041588728866" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -10615,7 +10651,7 @@
       <entries>
         <entry id="21971a8d-77bb-a9c4-98ca-07f241986d2a" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="ed1adf99-c04a-5e75-5cf8-89d95a718d37" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="ed1adf99-c04a-5e75-5cf8-89d95a718d37" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -10744,7 +10780,7 @@
         </entry>
         <entry id="09e858e4-cd27-0082-6cd6-efc71c37a7cd" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="6a7f976e-5963-23b8-be47-c8c2eb8a78cd" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="6a7f976e-5963-23b8-be47-c8c2eb8a78cd" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="13" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -10882,18 +10918,6 @@
       <rules/>
       <profiles/>
       <links/>
-    </entry>
-    <entry id="c023d12f-abd8-d7ba-03b5-ea21d0240ed0" name="M1 Garand rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2be53a3a-a992-8b9b-0ba2-7065b9bc17dd" targetId="d10b9427-70b3-2959-561d-6546fd4788cc" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
     </entry>
     <entry id="cd05186f-df2e-5414-efeb-ea333979f7b1" name="Rocket Launcher" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
       <entries/>
@@ -11304,7 +11328,7 @@
       <entries>
         <entry id="f88332aa-d57c-59fa-6200-f67ac0fa2bb3" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="ef6dae56-4efd-51a5-347c-4c64d9a2e102" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="ef6dae56-4efd-51a5-347c-4c64d9a2e102" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="8" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -11436,7 +11460,7 @@
       <entries>
         <entry id="a9af96ca-c7f8-00f4-8a6a-b8792a6cb14c" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="34904b73-8ba3-e7a0-9618-363cd7da8d2e" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="34904b73-8ba3-e7a0-9618-363cd7da8d2e" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -11568,7 +11592,7 @@
       <entries>
         <entry id="388050a6-1cc9-b972-e169-8f00b49b25d1" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="6131fb20-3e1e-2fc1-f6a2-e42c43d28b3d" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="6131fb20-3e1e-2fc1-f6a2-e42c43d28b3d" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -11594,7 +11618,7 @@
         </entry>
         <entry id="4e7a6db2-9179-3b40-85db-20e05c8b18f4" name="Tough Fighters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
           <entries>
-            <entry id="6bada20f-5fa2-018e-c4c5-27dcdef45a4a" name="Tough Fighters" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
+            <entry id="6bada20f-5fa2-018e-c4c5-27dcdef45a4a" name="Tough Fighters" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -11734,7 +11758,7 @@
         </entry>
         <entry id="123a8a06-6873-0926-1c9f-56b902abb909" name="Anti-tank Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
           <entries>
-            <entry id="54f616ff-7d7d-4844-0317-ca1b99a998c3" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="10" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
+            <entry id="54f616ff-7d7d-4844-0317-ca1b99a998c3" name="Anti-tank Grenades" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="13" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
               <entries/>
               <entryGroups/>
               <modifiers>
@@ -11876,30 +11900,6 @@
       <rules/>
       <profiles/>
       <links/>
-    </entry>
-    <entry id="898f-2600-c56e-dbd5" name="M1 Garand rifle or carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e586-db14-04ae-2d51" targetId="d10b9427-70b3-2959-561d-6546fd4788cc" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ad1d-b23e-6f69-c8d8" name="Pintle-Mounted HMG (360)" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="0">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="83b3-cea4-e687-4f36" targetId="a28fc6be-65f0-d015-c528-15adca14d14a" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
     </entry>
   </sharedEntries>
   <sharedEntryGroups/>


### PR DESCRIPTION
**File:** BA - Armies of the United States.cat

**Description:** My US Army roster contains 2 generic reinforced platoons. Each of them has a Platoon Commander and a M4A1 Sherman (among other things). But those two give me validation errors which say only one of each is allowed per ROSTER. Shouldn't that be per PLATOON?

Changed validations and artifacts from older versions of the list and Battlescribe.